### PR TITLE
STEP 7  : Swagger 및 주요 비즈니스 로직 개발 및 단위테스트

### DIFF
--- a/src/main/java/com/hhp7/concertreservation/domain/concert/model/Concert.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/model/Concert.java
@@ -1,4 +1,29 @@
 package com.hhp7.concertreservation.domain.concert.model;
 
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
 public class Concert {
+    private String id;
+    private String name;
+    private String artist;
+
+    private Concert(){}
+
+    public static Concert create(String id, String name, String artist) {
+        Concert concert = new Concert();
+        concert.id = id;
+        concert.name = name;
+        concert.artist = artist;
+        return concert;
+    }
+
+    public static Concert create(String name, String artist) {
+        Concert concert = new Concert();
+        concert.id = UUID.randomUUID().toString();
+        concert.name = name;
+        concert.artist = artist;
+        return concert;
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/model/ConcertSchedule.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/model/ConcertSchedule.java
@@ -1,4 +1,52 @@
 package com.hhp7.concertreservation.domain.concert.model;
 
+import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
 public class ConcertSchedule {
+    private String id;
+    private String concertId;
+    private LocalDateTime dateTime;
+    private LocalDateTime reservationStartAt;
+    private LocalDateTime reservationEndAt;
+
+    private ConcertSchedule() {}
+
+    // ID 포함 생성자
+    public static ConcertSchedule create(String id, String concertId, LocalDateTime dateTime, LocalDateTime reservationStartAt, LocalDateTime reservationEndAt){
+
+        if(reservationStartAt.isAfter(reservationEndAt)){
+            throw new BusinessRuleViolationException("예약 시작 일자는 예약 종료 일자보다 늦을 수 없습니다.");
+        }
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        concertSchedule.id = id;
+        concertSchedule.concertId = concertId;
+        concertSchedule.dateTime = dateTime;
+        concertSchedule.reservationStartAt = reservationStartAt;
+        concertSchedule.reservationEndAt = reservationEndAt;
+
+        return concertSchedule;
+    }
+
+    // ID 미포함 생성자
+    public static ConcertSchedule create(String concertId, LocalDateTime dateTime, LocalDateTime reservationStartAt, LocalDateTime reservationEndAt){
+        if(reservationStartAt.isAfter(reservationEndAt)){
+            throw new BusinessRuleViolationException("예약 시작 일자는 예약 종료 일자보다 늦을 수 없습니다.");
+        }
+
+        ConcertSchedule concertSchedule = new ConcertSchedule();
+        concertSchedule.id = UUID.randomUUID().toString();
+        concertSchedule.concertId = concertId;
+        concertSchedule.dateTime = dateTime;
+        concertSchedule.reservationStartAt = reservationStartAt;
+        concertSchedule.reservationEndAt = reservationEndAt;
+
+        return concertSchedule;
+    }
+
+
+
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/model/Seat.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/model/Seat.java
@@ -1,4 +1,59 @@
 package com.hhp7.concertreservation.domain.concert.model;
 
+import com.hhp7.concertreservation.domain.point.model.Point;
+import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
 public class Seat {
+    private String id;
+    private String concertScheduleId;
+    private int number; // 50번까지만 존재하도록 제약 필요.
+    private int price;
+    private SeatStatus status;
+
+    private Seat(){}
+
+    /* Seat 인스턴스를 생성하는 것은 해당 좌석에 대한 예약이 진행되어 특정 사용자에게 '할당'되었음을 의미합니다. */
+    public static Seat assign(String concertScheduleId, int number, int price, SeatStatus status){
+        // 비즈니스 정책 검증
+        if(number < 1 || number > 50){
+            throw new BusinessRuleViolationException("존재할 수 없는 좌석 번호입니다.");
+        }
+
+        Seat seat = new Seat();
+        seat.id = UUID.randomUUID().toString();
+        seat.concertScheduleId = concertScheduleId;
+        seat.number = number;
+        seat.price = price;
+        seat.status = status;
+
+        return seat;
+    }
+
+    public static Seat assign(String id, String concertScheduleId, int number, int price, SeatStatus status){
+        // 비즈니스 정책 검증
+        if(number < 1 || number > 50){
+            throw new BusinessRuleViolationException("존재할 수 없는 좌석 번호입니다.");
+        }
+        Seat seat = new Seat();
+        seat.id = id;
+        seat.concertScheduleId = concertScheduleId;
+        seat.number = number;
+        seat.price = price;
+        seat.status = status;
+
+        return seat;
+    }
+
+    // 도메인 로직 : 좌석 상태 변경
+    public void updateStatus(SeatStatus status){
+        this.status = status;
+    }
+
+    public boolean isAvailable(){
+        return this.status == SeatStatus.AVAILABLE;
+    }
+
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/model/SeatStatus.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/model/SeatStatus.java
@@ -1,4 +1,5 @@
 package com.hhp7.concertreservation.domain.concert.model;
 
 public enum SeatStatus {
+    AVAILABLE, UNAVAILABLE
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/repository/ConcertRepository.java
@@ -1,4 +1,14 @@
 package com.hhp7.concertreservation.domain.concert.repository;
 
+import com.hhp7.concertreservation.domain.concert.model.Concert;
+import java.util.Optional;
+
+
 public interface ConcertRepository {
+
+    // 콘서트 등록
+    Concert save(Concert concert);
+
+    // 콘서트 조회
+    Optional<Concert> findById(String concertId);
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/repository/ConcertScheduleRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/repository/ConcertScheduleRepository.java
@@ -1,4 +1,19 @@
 package com.hhp7.concertreservation.domain.concert.repository;
 
+import com.hhp7.concertreservation.domain.concert.model.ConcertSchedule;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+
 public interface ConcertScheduleRepository {
+
+    // 콘서트 일정 생성
+    ConcertSchedule save(ConcertSchedule concertSchedule);
+
+    // 콘서트 일정 조회
+    Optional<ConcertSchedule> findById(String concertScheduleId);
+
+    // 일정 상 예약 가능한 콘서트 목록 조회
+    List<ConcertSchedule> findAllByAvailableDatetime(LocalDateTime dateTime);
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/concert/repository/SeatRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/concert/repository/SeatRepository.java
@@ -1,4 +1,19 @@
 package com.hhp7.concertreservation.domain.concert.repository;
 
+import com.hhp7.concertreservation.domain.concert.model.Seat;
+import java.util.List;
+import java.util.Optional;
+
 public interface SeatRepository {
+
+    // 좌석 저장
+    Seat save(Seat seat);
+
+    // 좌석 조회
+    Optional<Seat> findById(String seatId);
+
+    // 특정 콘서트 일정의 예약 가능 좌석 목록 조회
+    List<Seat> findAllAvailableByConcertScheduleId(String concertScheduleId);
+
+
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/model/Point.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/model/Point.java
@@ -1,4 +1,134 @@
 package com.hhp7.concertreservation.domain.point.model;
 
-public class Point {
+import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
+import java.util.Objects;
+
+/**
+ * Point 개념 그 자체를 표현하는 도메인 모델(VO)입니다.
+ * <br></br>
+ * Q. 왜 Point 와 PointBalance 모델을 분리했나?
+ * <br>
+ * A. 포인트 감액/증액 이라는 개념은 '포인트 자체'에 대한 행위라기 보단 '사용자 잔액'에 대한 행위라고 생각하여 분리하였습니다.
+ * <br></br>
+ * Q. 왜 VO임에도 record 쓰지 않고 class를 썼나?
+ * <br>
+ * A. record 키워드는 Boilerplate 코드를 많이 줄여주며, 기본적으로 VO로 바로 활용하기 용이하도록 equals(), hashCode(), toString() 과 같은 메서드를 별도 정의없이도 제공해줍니다.
+ *   <br>
+ *    하지만 record 키워드를 사용할 경우 기본 생성자의 접근 수준을 제한할 수 없습니다.(class의 접근수준이 기본 생성자의 접근 수준에 강제됩니다.)
+ *    <br>
+ *    하지만 'Point는 음수가 될 수 없다'는 비즈니스 로직을 구현하기 위해선 이러한 기본 생성자에 대한 접근을 제한할 필요가 있었습니다.
+ *    <br>
+ *    이를 고려하여 다소 간 코드가 길어지는 점을 감수하고 class로 구현하였습니다.
+ */
+public final class Point {
+
+    /** 비즈니스 정책 : 사용자는 0점 이상 1,000,000점 이하의 포인트를 보유할 수 있다.**/
+    private static final int MAX_AMOUNT = 1_000_000;
+    private static final int MIN_AMOUNT = 0;
+
+    private final int amount;
+
+    /**
+     * 인자로 주어진 잔액을 갖는 새로운 {@code Point} 객체 인스턴스를 생성합니다.
+     * 이때 잔액에 대한 정책 준수 여부를 검증합니다. (잔액 in [0, 1,000,000])
+     *
+     * @param amount 생성될 {@code Point} 객체 인스턴스의 잔액량.
+     *                    주어진 잔액량은 0 이상 1,000,000 이하여야 한다.
+     * @return 주어진 양을 잔액으로 갖는 새로운 {@code Point} 객체 인스턴스.
+     * @throws BusinessRuleViolationException 잔액 정책 위반 시 발생하는 예외
+     */
+    private Point(int amount) {
+        this.amount = amount;
+    }
+
+    /**
+     * 주어진 양을 잔액으로 갖는 새로운 {@code Point} 객체 인스턴스를 생성한다.
+     *
+     * @param pointAmount 생성될 {@code Point} 객체 인스턴스의 잔액량.
+     *                    주어진 잔액량은 0 이상 1,000,000 이하여야 한다.
+     * @return 주어진 양을 잔액으로 갖는 새로운 {@code Point} 객체 인스턴스.
+     * @throws BusinessRuleViolationException 잔액 정책 위반 시 발생하는 예외
+     */
+    public static Point create(int pointAmount) {
+        if (pointAmount < MIN_AMOUNT) {
+            throw new BusinessRuleViolationException("사용자는 0보다 작은 포인트 잔액을 가질 수 없습니다.");
+        } else if (pointAmount > MAX_AMOUNT) {
+            throw new BusinessRuleViolationException("사용자의 보유 포인트 최대 한도는 1,000,000점 입니다.");
+        }
+        return new Point(pointAmount);
+    }
+
+    /**
+     * 현재 포인트 잔액을 반환한다.
+     *
+     * @return 포인트 잔액
+     */
+    public int getAmount() {
+        return amount;
+    }
+
+    /**
+     * {@code Point} 객체의 잔액을 증가시킨 새로운 인스턴스를 반환한다.
+     *
+     * @param increment 증가시킬 포인트 양
+     * @return 증가된 포인트 잔액을 가진 새로운 {@code Point} 객체 인스턴스
+     * @throws BusinessRuleViolationException 증가 후 잔액이 최대 한도를 초과할 경우 발생
+     */
+    public Point increase(int increment) {
+        long newAmount = (long) this.amount + increment;
+        if (newAmount > MAX_AMOUNT) {
+            throw new BusinessRuleViolationException("포인트 증액으로 인해 최대 한도를 초과했습니다.");
+        }
+        return new Point((int) newAmount);
+    }
+
+    /**
+     * {@code Point} 객체의 잔액을 감소시킨 새로운 인스턴스를 반환한다.
+     *
+     * @param decrement 감소시킬 포인트 양
+     * @return 감소된 포인트 잔액을 가진 새로운 {@code Point} 객체 인스턴스
+     * @throws BusinessRuleViolationException 감소 후 잔액이 최소 한도 미만일 경우 발생
+     */
+    public Point decrease(int decrement) {
+        long newAmount = (long) this.amount - decrement;
+        if (newAmount < MIN_AMOUNT) {
+            throw new BusinessRuleViolationException("포인트 감액으로 인해 잔액이 음수가 될 수 없습니다.");
+        }
+        return new Point((int) newAmount);
+    }
+
+    /**
+     * {@code Point} 객체의 동등성을 비교한다.
+     *
+     * @param o 비교 대상 객체
+     * @return 두 객체의 잔액이 같으면 {@code true}, 아니면 {@code false}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Point point)) return false;
+        return amount == point.amount;
+    }
+
+    /**
+     * {@code Point} 객체의 해시 코드를 반환
+     *
+     * @return 포인트 잔액을 기반으로 한 해시 코드
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount);
+    }
+
+    /**
+     * {@code Point} 객체의 문자열 표현을 반환
+     *
+     * @return 포인트 잔액을 포함한 문자열
+     */
+    @Override
+    public String toString() {
+        return "Point{" +
+                "amount=" + amount +
+                '}';
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/model/PointHistory.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/model/PointHistory.java
@@ -1,4 +1,31 @@
 package com.hhp7.concertreservation.domain.point.model;
 
-public record PointHistory() {
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PointHistory(
+        String pointHistoryId,
+        String userId,
+        PointTransactionType transactionType,
+        int transactionAmount,
+        LocalDateTime transactionDate
+) {
+    public static PointHistory create(String userId,
+                                      PointTransactionType transactionType,
+                                      int transactionAmount){
+        return new PointHistory(
+                String.valueOf(UUID.randomUUID()),
+                userId,
+                transactionType,
+                transactionAmount,
+                LocalDateTime.now());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof PointHistory pointHistory){
+            return this.pointHistoryId().equals(pointHistory.pointHistoryId());
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/model/PointTransactionType.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/model/PointTransactionType.java
@@ -1,4 +1,10 @@
 package com.hhp7.concertreservation.domain.point.model;
 
+/**
+ * 사용자 포인트 사용/차감 표현을 위한 Enum
+ */
 public enum PointTransactionType {
+    CHARGE,
+    USE,
+    INIT
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/model/UserPointBalance.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/model/UserPointBalance.java
@@ -1,4 +1,63 @@
 package com.hhp7.concertreservation.domain.point.model;
 
-public record UserPointBalance() {
+import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
+
+/**
+ * '사용자의 잔액'을 표현하는 도메인 모델입니다.
+ * 실제 포인트 감액/증액에 대한 비즈니스 로직에 대한 책임을 가집니다.
+ * @param userId
+ * @param balance
+ */
+public record UserPointBalance(
+        String userId,
+        Point balance
+) {
+    public static UserPointBalance create(String userId, Point balance){
+        return new UserPointBalance(userId, balance); // Point 객체 생성 시 해당 포인트가 비즈니스 정책을 위반할 경우 Point 생성 시점에 예외가 발생합니다.
+    }
+
+    /**
+     * 비즈니스 정책을 위반하지 않는 경우, 사용자의 포인트 잔액을 증가시킵니다.
+     *
+     * @param increaseAmount 더해질 포인트 양. 해당 양은 0 이상이어야 하며, 이를 기존 잔액과 더했을 때 총합은 1,000,000점 이하여야 한다.
+     * @return (기존 보유량 + 인자로 주어진 추가량) 을 잔액으로 갖는 새로운 {@code UserPointBalance} 객체 인스턴스를 생성하여 반환한다.
+     * @throws BusinessRuleViolationException 충전하고자 하는 양이 0 미만이거나 기존 잔액과 합이 1,000,000 점 초과하는 경우
+     */
+    public UserPointBalance increase(int increaseAmount){
+        // Fail : 0보다 작은 충전 금액 충전 시도
+        if(increaseAmount < 0){
+            throw new BusinessRuleViolationException("충전하고자 하는 포인트는 0보다 커야 합니다.");
+        }
+
+        int newAmount = this.balance().getAmount() + increaseAmount;
+
+        // Fail : 기존 잔액과 합산 시 최대 한도 초과하는 금액 충전 시도
+        if(newAmount > 1_000_000){
+            throw new BusinessRuleViolationException("잔액 최대 보유 한도는 1,000,000점입니다. 초과하여 충전이 불가합니다.");
+        }
+        // Success : 합산된 잔액을 갖는 새로운 UserPointBalance 객체 인스턴스 생성 후 반환.
+        return UserPointBalance.create(this.userId(), Point.create(newAmount));
+    }
+
+
+    /**
+     * 비즈니스 정책을 위반하지 않는 경우, 사용자의 포인트 잔액을 차감시킵니다.
+     *
+     * @param decreaseAmount 차감할 포인트 양.
+     *                       차감량은 0보다 작아선 안되며, 차감 시 잔액이 0보다 작아져서도 안된다.
+     * @return 차감된 금액을 잔액으로 갖는 새로운 {@code Point} 객체 인스턴스를 생성하여 반환한다.
+     * @throws IllegalArgumentException 차감할 포인트 양이 0보다 작거나, 차감 시 잔액이 0보다 작아지는 경우 해당 예외 발생.
+     */
+    public UserPointBalance decrease(int decreaseAmount){
+        if(decreaseAmount < 0){
+            throw new IllegalArgumentException("차감하고자 하는 포인트는 0보다 커야합니다.");
+        }
+
+        else if(decreaseAmount > 1_000_000){
+            throw new IllegalArgumentException("차감 시 보유 잔액이 0원 미만이 되므로 해당 차감은 불가합니다.");
+        }
+
+        int newAmount = this.balance().getAmount() - decreaseAmount;
+        return UserPointBalance.create(this.userId(), Point.create(newAmount));
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/repository/PointHistoryRepository.java
@@ -1,4 +1,14 @@
 package com.hhp7.concertreservation.domain.point.repository;
 
+import com.hhp7.concertreservation.domain.point.model.PointHistory;
+import java.util.List;
+import java.util.Optional;
+
 public interface PointHistoryRepository {
+
+    // 포인트 내역 저장
+    PointHistory save(PointHistory pointHistory);
+
+    // 사용자 포인트 내역 가져오기
+    List<PointHistory> findByUserId(String userId);
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/repository/UserPointBalanceRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/repository/UserPointBalanceRepository.java
@@ -1,4 +1,13 @@
 package com.hhp7.concertreservation.domain.point.repository;
 
+import com.hhp7.concertreservation.domain.point.model.UserPointBalance;
+import java.util.Optional;
+
 public interface UserPointBalanceRepository {
+
+    // 사용자 포인트 잔액 조회
+    Optional<UserPointBalance> getBalanceByUserId(String userId);
+
+    // 사용자 포인트 잔액 저장
+    UserPointBalance save(UserPointBalance userPointBalance);
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/point/service/PointService.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/point/service/PointService.java
@@ -1,4 +1,88 @@
 package com.hhp7.concertreservation.domain.point.service;
 
+import com.hhp7.concertreservation.domain.point.model.Point;
+import com.hhp7.concertreservation.domain.point.model.PointHistory;
+import com.hhp7.concertreservation.domain.point.model.PointTransactionType;
+import com.hhp7.concertreservation.domain.point.model.UserPointBalance;
+import com.hhp7.concertreservation.domain.point.repository.PointHistoryRepository;
+import com.hhp7.concertreservation.domain.point.repository.UserPointBalanceRepository;
+import com.hhp7.concertreservation.exceptions.UnavailableRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class PointService {
+    private final PointHistoryRepository pointHistoryRepository;
+    private final UserPointBalanceRepository userPointBalanceRepository;
+
+    /**
+     * 특정 사용자의 포인트 잔액을 감액한 후 변동된 잔액을 저장하고 이를 반환한다.
+     * <br></br>
+     * 또한, 이에 대한 내역을 생성하여 저장한다.
+     *
+     * @param userId 사용자 ID
+     * @param decreaseAmount 감액량
+     * @return 변동된 사용자의 잔액
+     */
+    public UserPointBalance decreaseUserPointBalance(String userId, int decreaseAmount){
+        UserPointBalance userPointBalance = userPointBalanceRepository.getBalanceByUserId(userId)
+                .orElseThrow(() -> new UnavailableRequestException("해당 회원이 존재하지 않으므로 잔액 조회가 불가합니다."));;
+        userPointBalance.decrease(decreaseAmount);
+        PointHistory pointHistory = PointHistory.create(
+                userId,
+                PointTransactionType.USE,
+                decreaseAmount
+        );
+        pointHistoryRepository.save(pointHistory);
+        return userPointBalanceRepository.save(userPointBalance);
+    }
+
+    /**
+     * 특정 사용자의 포인트 잔액을 증액한 후 변동된 잔액을 저장하고 이를 반환한다.
+     * <br></br>
+     * 또한, 이에 대한 내역을 생성하여 저장한다.
+     *
+     * @param userId 사용자 ID
+     * @param increaseAmount 증액량
+     * @return 변동된 사용자의 잔액
+     */
+    public UserPointBalance increaseUserPointBalance(String userId, int increaseAmount){
+        UserPointBalance userPointBalance = userPointBalanceRepository.getBalanceByUserId(userId)
+                .orElseThrow(() -> new UnavailableRequestException("해당 회원이 존재하지 않으므로 잔액 조회가 불가합니다."));
+        userPointBalance.increase(increaseAmount);
+        PointHistory pointHistory = PointHistory.create(
+                userId,
+                PointTransactionType.CHARGE,
+                increaseAmount
+        );
+        pointHistoryRepository.save(pointHistory);
+        return userPointBalanceRepository.save(userPointBalance);
+
+    }
+
+    /**
+     * 신규 사용자의 포인트 잔액과 이에 대한 내역을 생성 및 저장한다.
+     * <br></br>
+     * 잔액 0인 UserPointBalance를 반환한다.
+     *
+     * @param userId 사용자 ID
+     * @return 잔액 0인 사용자 잔액
+     * */
+    public UserPointBalance createUserPointBalance(String userId){
+        UserPointBalance userPointBalance = UserPointBalance.create(userId, Point.create(0));
+        pointHistoryRepository.save(PointHistory.create(userId, PointTransactionType.INIT, 0));
+        return userPointBalanceRepository.save(userPointBalance);
+    }
+
+    /**
+     * 특정 사용자의 잔액 조회
+     *
+     * @param userId 사용자 ID
+     * @return 해당 사용자의 포인트 잔액
+     */
+    public UserPointBalance getUserPointBalance(String userId){
+        return userPointBalanceRepository.getBalanceByUserId(userId)
+                .orElseThrow(() -> new UnavailableRequestException("해당 회원이 존재하지 않으므로 잔액 조회가 불가합니다."));
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/user/model/User.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/user/model/User.java
@@ -1,4 +1,39 @@
 package com.hhp7.concertreservation.domain.user.model;
 
+import com.hhp7.concertreservation.domain.point.model.Point;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
 public class User {
+    private final String id;
+    private final String name;
+
+    // 기본 생성자. : Private
+    private User(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+
+    public static User create(String id, String name){
+        return new User(id, name);
+    }
+
+    // 실제 생성 시에는 사용자의 이름만 받아 생성하게 되므로 다음과 같은 팩토리 메서드를 정의한다.
+    public static User create(String name){
+        return new User(
+                String.valueOf(UUID.randomUUID())
+                , name
+        );
+    }
+
+    // Domain Model Entity 간 비교를 위해 equals() 구현.
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof User user) {
+            return this.id.equals(user.id);
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/user/repository/UserRepository.java
@@ -1,4 +1,14 @@
 package com.hhp7.concertreservation.domain.user.repository;
 
+import com.hhp7.concertreservation.domain.user.model.User;
+import java.util.Optional;
+
 public interface UserRepository {
+
+    // 회원 조회
+    Optional<User> findUserByUserId(String userId);
+
+    // 회원 가입
+    User joinUser(User user);
+
 }

--- a/src/main/java/com/hhp7/concertreservation/domain/user/service/UserService.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/user/service/UserService.java
@@ -1,4 +1,25 @@
 package com.hhp7.concertreservation.domain.user.service;
 
+import com.hhp7.concertreservation.domain.user.model.User;
+import com.hhp7.concertreservation.domain.user.repository.UserRepository;
+import com.hhp7.concertreservation.exceptions.UnavailableRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+    private final UserRepository userRepository;
+
+    // 회원 가입
+    public User joinUser(User user) {
+        return userRepository.joinUser(user);
+    }
+
+    // 회원 조회
+    public User findUserByUserId(String userId) {
+        return userRepository.findUserByUserId(userId)
+                .orElseThrow(() -> new UnavailableRequestException("해당 사용자가 존재하지 않으므로 조회가 불가합니다."));
+    }
+
 }

--- a/src/main/java/com/hhp7/concertreservation/exceptions/BusinessRuleViolationException.java
+++ b/src/main/java/com/hhp7/concertreservation/exceptions/BusinessRuleViolationException.java
@@ -1,0 +1,7 @@
+package com.hhp7.concertreservation.exceptions;
+
+public class BusinessRuleViolationException extends RuntimeException {
+    public BusinessRuleViolationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/exceptions/UnavailableRequestException.java
+++ b/src/main/java/com/hhp7/concertreservation/exceptions/UnavailableRequestException.java
@@ -1,0 +1,18 @@
+package com.hhp7.concertreservation.exceptions;
+
+/**
+ * 성립할 수 없는 요청에 대해 발생하는 예외입니다.
+ * <br></br>
+ * <i>성립할 수 없는 요청</i>은 다음으로 정의됩니다.
+ * <br></br>
+ * - 예약 가능한 시점이 아닐 때 예약을 시도하는 경우.
+ * <br>
+ * - 이미 예약된 좌석에 대한 예약을 시도하는 경우
+ * <br>
+ * -
+ */
+public class UnavailableRequestException extends RuntimeException {
+    public UnavailableRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/ConcertJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/ConcertJpaRepository.java
@@ -1,0 +1,7 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.ConcertJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConcertJpaRepository extends JpaRepository<ConcertJpaEntity, String> {
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/ConcertScheduleJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/ConcertScheduleJpaRepository.java
@@ -1,0 +1,14 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.ConcertScheduleJpaEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ConcertScheduleJpaRepository extends JpaRepository<ConcertScheduleJpaEntity, String> {
+
+    @Query("SELECT cs FROM ConcertScheduleJpaEntity cs WHERE cs.reservationStartAt <= :now AND cs.reservationEndAt >= :now")
+    List<ConcertScheduleJpaEntity> findAllAvailableConcertSchedule(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/PointHistoryJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/PointHistoryJpaRepository.java
@@ -1,0 +1,10 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.PointHistoryJpaEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointHistoryJpaRepository extends JpaRepository<PointHistoryJpaEntity, String> {
+
+    List<PointHistoryJpaEntity> findByUserId(String userId);
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/SeatJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/SeatJpaRepository.java
@@ -1,0 +1,13 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.SeatJpaEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatJpaRepository extends JpaRepository<SeatJpaEntity, String> {
+
+    Optional<SeatJpaEntity> findBySeatId(String seatId);
+
+    List<SeatJpaEntity> findAllByConcertScheduleId(String concertScheduleId);
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.UserJpaEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, String> {
+
+    Optional<UserJpaEntity> findByUserId(String userId);
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/UserPointBalanceJpaRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/UserPointBalanceJpaRepository.java
@@ -1,0 +1,10 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.UserPointBalanceJpaEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPointBalanceJpaRepository extends JpaRepository<UserPointBalanceJpaEntity, String> {
+
+    Optional<UserPointBalanceJpaEntity> findByUserId(String userId);
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/BaseJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/BaseJpaEntity.java
@@ -1,4 +1,24 @@
 package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
 
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseJpaEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
 }

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/ConcertJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/ConcertJpaEntity.java
@@ -1,0 +1,35 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+import com.hhp7.concertreservation.domain.concert.model.Concert;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "CONCERT")
+@Getter
+public class ConcertJpaEntity extends BaseJpaEntity {
+    @Id
+    @Column(name = "concert_id")
+    private String concertId;
+    private String name;
+    private String artist;
+
+    public static ConcertJpaEntity fromDomainModel(Concert concert) {
+        ConcertJpaEntity entity = new ConcertJpaEntity();
+        entity.concertId = concert.getId();
+        entity.name = concert.getName();
+        entity.artist = concert.getArtist();
+
+        return entity;
+    }
+
+    public Concert toDomainModel(){
+        return Concert.create(
+                this.concertId,
+                this.name,
+                this.artist);
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/ConcertScheduleJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/ConcertScheduleJpaEntity.java
@@ -1,0 +1,42 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+import com.hhp7.concertreservation.domain.concert.model.ConcertSchedule;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "CONCERT_SCHEDULE")
+public class ConcertScheduleJpaEntity extends BaseJpaEntity {
+    @Id
+    @Column(name = "concert_schedule_id")
+    private String concertScheduleId;
+    private String concertId;
+    private LocalDateTime datetime;
+    private LocalDateTime reservationStartAt;
+    private LocalDateTime reservationEndAt;
+
+    public static ConcertScheduleJpaEntity fromDomainModel(ConcertSchedule domainModel) {
+        ConcertScheduleJpaEntity entity = new ConcertScheduleJpaEntity();
+        entity.concertScheduleId = domainModel.getId();
+        entity.concertId = domainModel.getConcertId();
+        entity.datetime = domainModel.getDateTime();
+        entity.reservationStartAt = domainModel.getReservationStartAt();
+        entity.reservationEndAt = domainModel.getReservationEndAt();
+
+        return entity;
+    }
+
+    public ConcertSchedule toDomainModel(){
+        return ConcertSchedule.create(
+                this.concertScheduleId,
+                this.concertId,
+                this.datetime,
+                this.reservationStartAt,
+                this.reservationEndAt);
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/PointHistoryJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/PointHistoryJpaEntity.java
@@ -1,0 +1,43 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+import com.hhp7.concertreservation.domain.point.model.Point;
+import com.hhp7.concertreservation.domain.point.model.PointTransactionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import com.hhp7.concertreservation.domain.point.model.PointHistory;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class PointHistoryJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @Column(name = "point_history_id")
+    private String id;
+    private String userId;
+    private int point;
+    private String transactionType;
+    private String description;
+
+
+    public static PointHistory toDomainModel(PointHistoryJpaEntity entity) {
+        return new PointHistory(
+                entity.getId(),
+                entity.getUserId(),
+                PointTransactionType.valueOf(entity.getTransactionType()),
+                entity.getPoint(),
+                entity.getCreated_at()
+        );
+    }
+
+    public static PointHistoryJpaEntity fromDomainModel(PointHistory pointHistory) {
+        PointHistoryJpaEntity entity = new PointHistoryJpaEntity();
+        entity.id = pointHistory.pointHistoryId();
+        entity.userId = pointHistory.userId();
+        entity.point = pointHistory.transactionAmount();
+        entity.transactionType = String.valueOf(pointHistory.transactionType());
+        return entity;
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/SeatJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/SeatJpaEntity.java
@@ -1,0 +1,38 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+import com.hhp7.concertreservation.domain.concert.model.Seat;
+import com.hhp7.concertreservation.domain.concert.model.SeatStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "SEAT")
+public class SeatJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @Column(name = "seat_id")
+    private String seatId;
+
+    private String concertScheduleId;
+    private int number;
+    private int price;
+    private String status;
+
+    public static SeatJpaEntity fromDomainModel(Seat seat) {
+        SeatJpaEntity entity = new SeatJpaEntity();
+        entity.seatId = seat.getId();
+        entity.concertScheduleId = seat.getConcertScheduleId();
+        entity.number = seat.getNumber();
+
+        return entity;
+    }
+
+    public Seat toDomainModel() {
+        return Seat.assign(seatId, concertScheduleId, number, price, SeatStatus.valueOf(status));
+    }
+
+
+
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/UserJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/UserJpaEntity.java
@@ -1,0 +1,44 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+
+import com.hhp7.concertreservation.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "USER")
+@Getter
+@NoArgsConstructor
+public class UserJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private String userId; // Domain Model 의 ID(String.valueOf(UUID))를 함께 사용합니다.
+    private String name;
+
+    public UserJpaEntity(String userId, String name) {
+        this.userId = userId;
+        this.name = name;
+    }
+
+    // User -> UserJpaEntity
+    public static UserJpaEntity fromDomain(User domainUser) {
+        return new UserJpaEntity(
+                domainUser.getId()
+                , domainUser.getName());
+    }
+
+    // UserJpaEntity -> User
+    public User toDomain() {
+        return User.create(
+                this.getUserId(),
+                this.getName()
+        );
+    }
+
+
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/UserPointBalanceJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/entities/UserPointBalanceJpaEntity.java
@@ -1,0 +1,36 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.entities;
+
+import com.hhp7.concertreservation.domain.point.model.Point;
+import com.hhp7.concertreservation.domain.point.model.UserPointBalance;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "POINTBALANCE")
+public class UserPointBalanceJpaEntity extends BaseJpaEntity{
+
+    @Id @GeneratedValue
+    @Column(name = "point_balance_id")
+    private Long id;
+    private String userId;
+    private int point;
+
+    // UserPointModel(Domain Model) -> UserPointBalanceJpaEntity(JPA entity model)
+    public static UserPointBalanceJpaEntity fromDomainModel(UserPointBalance domainModel) {
+        UserPointBalanceJpaEntity entity = new UserPointBalanceJpaEntity();
+        entity.userId = domainModel.userId();
+        entity.point = domainModel.balance().getAmount();
+        return entity;
+    }
+
+
+    // UserPointBalanceJpaEntity(JPA entity model) -> UserPointModel(Domain Model)
+    public UserPointBalance toDomainModel() {
+        return new UserPointBalance(this.userId, Point.create(this.point));
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/ConcertRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/ConcertRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.impl;
+
+import com.hhp7.concertreservation.domain.concert.model.Concert;
+import com.hhp7.concertreservation.domain.concert.repository.ConcertRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.ConcertJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.ConcertJpaEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConcertRepositoryImpl implements ConcertRepository {
+
+    private final ConcertJpaRepository concertJpaRepository;
+
+    @Override
+    public Concert save(Concert concert) {
+        return concertJpaRepository.save(ConcertJpaEntity.fromDomainModel(concert))
+                .toDomainModel();
+    }
+
+    @Override
+    public Optional<Concert> findById(String concertId) {
+        return concertJpaRepository.findById(concertId)
+                .map(ConcertJpaEntity::toDomainModel);
+    }
+}
+

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/ConcertScheduleRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/ConcertScheduleRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.impl;
+
+import com.hhp7.concertreservation.domain.concert.model.ConcertSchedule;
+import com.hhp7.concertreservation.domain.concert.repository.ConcertScheduleRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.ConcertScheduleJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.ConcertScheduleJpaEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConcertScheduleRepositoryImpl implements ConcertScheduleRepository {
+    private final ConcertScheduleJpaRepository concertScheduleJpaRepository;
+
+    @Override
+    public ConcertSchedule save(ConcertSchedule concertSchedule) {
+        return concertScheduleJpaRepository.save(ConcertScheduleJpaEntity.fromDomainModel(concertSchedule))
+                .toDomainModel();
+    }
+
+    @Override
+    public Optional<ConcertSchedule> findById(String concertScheduleId) {
+        return concertScheduleJpaRepository.findById(concertScheduleId)
+                .map(ConcertScheduleJpaEntity::toDomainModel);
+    }
+
+    @Override
+    public List<ConcertSchedule> findAllByAvailableDatetime(LocalDateTime dateTime) {
+        return concertScheduleJpaRepository.findAllAvailableConcertSchedule(dateTime)
+                .stream()
+                .map(ConcertScheduleJpaEntity::toDomainModel)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/PointHistoryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.impl;
+
+import com.hhp7.concertreservation.domain.point.model.PointHistory;
+import com.hhp7.concertreservation.domain.point.repository.PointHistoryRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.PointHistoryJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.PointHistoryJpaEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointHistoryRepositoryImpl implements PointHistoryRepository {
+    private final PointHistoryJpaRepository pointHistoryJpaRepository;
+
+    @Override
+    public PointHistory save(PointHistory pointHistory) {
+        return PointHistoryJpaEntity.toDomainModel(
+                pointHistoryJpaRepository
+                        .save(PointHistoryJpaEntity.fromDomainModel(pointHistory))
+        );
+    }
+
+    @Override
+    public List<PointHistory> findByUserId(String userId) {
+        return pointHistoryJpaRepository
+                .findByUserId(userId)
+                .stream()
+                .map(PointHistoryJpaEntity::toDomainModel)
+                .toList();
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/SeatRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/SeatRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.impl;
+
+import com.hhp7.concertreservation.domain.concert.model.Seat;
+import com.hhp7.concertreservation.domain.concert.repository.SeatRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.SeatJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.SeatJpaEntity;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatRepositoryImpl implements SeatRepository {
+
+    private final SeatJpaRepository seatJpaRepository;
+
+    @Override
+    public Seat save(Seat seat) {
+        return seatJpaRepository.save(SeatJpaEntity.fromDomainModel(seat))
+                .toDomainModel();
+    }
+
+    @Override
+    public Optional<Seat> findById(String seatId) {
+        return seatJpaRepository.findBySeatId(seatId)
+                .map(SeatJpaEntity::toDomainModel);
+    }
+
+    @Override
+    public List<Seat> findAllAvailableByConcertScheduleId(String concertScheduleId) {
+        return seatJpaRepository.findAllByConcertScheduleId(concertScheduleId)
+                .stream()
+                .map(SeatJpaEntity::toDomainModel)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/UserPointBalanceRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/UserPointBalanceRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.hhp7.concertreservation.infrastructure.persistence.jpa.impl;
+
+import com.hhp7.concertreservation.domain.point.model.UserPointBalance;
+import com.hhp7.concertreservation.domain.point.repository.UserPointBalanceRepository;
+import com.hhp7.concertreservation.exceptions.UnavailableRequestException;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.UserPointBalanceJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.UserPointBalanceJpaEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserPointBalanceRepositoryImpl implements UserPointBalanceRepository {
+
+    private final UserPointBalanceJpaRepository userPointBalanceJpaRepository;
+
+    @Override
+    public Optional<UserPointBalance> getBalanceByUserId(String userId) {
+        return userPointBalanceJpaRepository.findByUserId(userId)
+                .map(UserPointBalanceJpaEntity::toDomainModel);
+    }
+
+    @Override
+    public UserPointBalance save(UserPointBalance userPointBalance) {
+        return userPointBalanceJpaRepository.save(
+                        UserPointBalanceJpaEntity.fromDomainModel(userPointBalance))
+                .toDomainModel();
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/persistence/jpa/impl/UserRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.hhp7.concertreservation.infrastructure.persistence.impl;
+
+import com.hhp7.concertreservation.domain.user.model.User;
+import com.hhp7.concertreservation.domain.user.repository.UserRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.UserJpaRepository;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.UserJpaEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findUserByUserId(String userId) {
+        return userJpaRepository.findByUserId(userId)
+                .map(UserJpaEntity::toDomain);
+    }
+
+    @Override
+    public User joinUser(User user) {
+        return userJpaRepository.save(UserJpaEntity.fromDomain(user)).toDomain();
+    }
+}

--- a/src/test/java/com/hhp7/concertreservation/domain/point/model/PointBalanceTest.java
+++ b/src/test/java/com/hhp7/concertreservation/domain/point/model/PointBalanceTest.java
@@ -1,0 +1,39 @@
+package com.hhp7.concertreservation.domain.point.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code PointBalance} 도메인 모델에 대한 단위 테스트
+ */
+public class PointBalanceTest {
+
+    @Test
+    @DisplayName("실패 : 0보다 적은 금액 차감 시도할 경우 BusinessRuleViolationException 발생하며 실패")
+    void shouldThrowBusinessRuleViolationException_WhenNegativeAmountDecrease(){
+        // given
+        Point point = Point.create(1000);
+        UserPointBalance userPointBalance = UserPointBalance.create("1",point);
+        int negativeAmount = -1;
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> userPointBalance.decrease(negativeAmount))
+                .isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    @DisplayName("실패 : 1_000_000 초과 금액 차감 시도 시 BusinessRuleViolationException 발생하며 실패.")
+    void shouldThrowBusinessRuleViolationException_WhenDecreaseAmountExceedsMillion(){
+        // given
+        Point point = Point.create(1000);
+        UserPointBalance userPointBalance = UserPointBalance.create("1",point);
+        int overMillion = 1_000_001;
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> userPointBalance.decrease(overMillion))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/src/test/java/com/hhp7/concertreservation/domain/point/model/PointTest.java
+++ b/src/test/java/com/hhp7/concertreservation/domain/point/model/PointTest.java
@@ -1,0 +1,49 @@
+package com.hhp7.concertreservation.domain.point.model;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code Point} 도메인 모델에 대한 단위테스트.
+ */
+
+class PointTest {
+
+    @Test
+    @DisplayName("실패 : 0보다 적은 금액을 가진 Point 객체 인스턴스 생성 시도 시 BusinessRuleViolationException 발생.")
+    void shouldThrowBusinessRuleViolationException_WhenAmountBelowZero(){
+        // given
+        int negativeAmount = -1;
+
+        // when & then
+        assertThatThrownBy(() -> Point.create(negativeAmount))
+                .isInstanceOf(BusinessRuleViolationException.class);
+    }
+
+    @Test
+    @DisplayName("실패 : 1,000,000 점을 초과하는 금액을 갖는 Point 객체 인스턴스 생성 시도 시 BusinessRuleViolationException 발생")
+    void shouldThrowBusinessRuleViolationException_WhenAmountOverMillion(){
+        // given
+        int overMillion = 1_000_001;
+
+        // when & then
+        assertThatThrownBy(() -> Point.create(overMillion))
+                .isInstanceOf(BusinessRuleViolationException.class);
+    }
+
+    @Test
+    @DisplayName("성공 : 적법한 금액을 갖는 Point 객체 인스턴스 생성 시도는 성공한다.")
+    void shouldSucceed_WhenAmountIsLegal(){
+        // given
+        int legalAmount = 1000;
+
+        // when & then
+        Assertions.assertThatCode(() -> Point.create(legalAmount))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/src/test/java/com/hhp7/concertreservation/domain/user/service/UserServiceUnitTest.java
+++ b/src/test/java/com/hhp7/concertreservation/domain/user/service/UserServiceUnitTest.java
@@ -1,0 +1,65 @@
+package com.hhp7.concertreservation.domain.user.service;
+
+import com.hhp7.concertreservation.domain.user.model.User;
+import com.hhp7.concertreservation.domain.user.repository.UserRepository;
+import com.hhp7.concertreservation.exceptions.UnavailableRequestException;
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.UserJpaRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+// UserService 단위 테스트
+public class UserServiceUnitTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("실패 : 존재하지 않는 회원 조회 시 UnavailableRequestException 발생하며 실패한다.")
+    void shouldThrowUnavailableRequestException_WhenUserNotFound(){
+        // given
+        String userId = "1";
+
+        // when & then
+        Mockito.when(userRepository.findUserByUserId(userId))
+                .thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> {
+                    userService.findUserByUserId(userId);
+                })
+                .isInstanceOf(UnavailableRequestException.class)
+                .hasMessageContaining("해당 사용자가 존재하지 않으므로 조회가 불가합니다.");
+    }
+
+    @Test
+    @DisplayName("성공 : 회원 가입 시 새로운 회원 조회가 가능해진다.")
+    void shouldReturnUser_WhenNewUserIsSaved(){
+        // given
+        String userId = "1";
+        String userName = "우도균";
+        User expectedUser = User.create("우도균");
+
+        Mockito.when(userRepository.findUserByUserId(userId))
+                .thenReturn(Optional.of(expectedUser));
+        // when
+        User actualUser = userService.findUserByUserId(userId);
+
+        // then
+        Assertions.assertThat(actualUser).isEqualTo(expectedUser);
+    }
+
+}


### PR DESCRIPTION
## 완료 작업 내역
### 1. 아키텍처 재설계 및 설계 근거
- [링크](https://github.com/leonroars/hhp7-concert-reservation/pull/3#issue-2779017995)

### 2.  `user`, `point` : 도메인 비즈니스 로직 구현 및 단위 테스트 완료
> `user`
 - [구현](https://github.com/leonroars/hhp7-concert-reservation/pull/4/commits/976d669b79292fb4006212d699bf77e162ad1bbd)
 - [단위 테스트](https://github.com/leonroars/hhp7-concert-reservation/pull/4/commits/d98ae58aadd726d72d4093af16a55fc50ca2ddca)
 
 > `point` 
- [구현](https://github.com/leonroars/hhp7-concert-reservation/pull/4/commits/5f8c5a7b740944f1fcde739384429330911784e5)
- [단위테스트](https://github.com/leonroars/hhp7-concert-reservation/pull/4/commits/4481388d54f7a8e27a1751746aa62b4affbfcf68)

> `concert`
- [구현](https://github.com/leonroars/hhp7-concert-reservation/pull/4/commits/44732d0d78d8384d60d17367a7bd9c78a6095443)
 
### 3. Swagger 기능 구현 및 캡쳐본 첨부
<img width="1504" alt="Screenshot 2025-01-10 at 9 59 16 AM" src="https://github.com/user-attachments/assets/f214c1ac-84b8-4e3b-a7f4-cc2f9d620bb0" />

## 진행하지 못한 작업 내역
1. `concert` : 도메인 서비스(`ConcertService`) 구현 및 단위 테스트
2. `Queue` 애거리거트 구현
3.  Scheduler 및 Application 계층 개발
4. 통합테스트

## 피드백 요청 내용
 1. 사용자 잔액 조회 로직 타당성에 대한 피드백을 요청드립니다.
 - 현재 지난 멘토링 당시 말씀해주셨던 내용 (User / Point 분리)를 고민한 후에 이를 분리하는 것이 적절하다고 생각하여 분리하게 되었습니다.
    이때 사용자 잔액 조회의 책임은 `point` 가 갖게 되어, 사용자 잔액 조회 시 `userId`를 메서드 인자로 받아 조회 후 결과를 반환하는 구현이 되었습니다.
    이렇게 경계 너머(다른 Aggregate)의 값을 활용하여 비즈니스 로직을 수행해도 괜찮은지 여쭤보고싶습니다.
    도메인의 경계 및 책임 분리가 불분명해지는 것은 아닌가 걱정이 됩니다...
  
 2. "예약 가능 콘서트 일정 조회" 구현 로직이 괜찮은지 여쭤보고 싶습니다!
  - 지난 멘토링 말씀해주셨던 대로 `Seat` 도메인 모델을 Concert 애거리거트로 편입시켰습니다.
     확실히 이렇게 하고 나니 보다 관심사 간 분리 경계가 보다 명확해서 좋다고 느껴졌습니다.
     하지만 이렇게 해두고나니 역시나 <u>"예약 가능 콘서트 일정 목록 조회"를 구현하는 방식이 까다로웠습니다</u>.

     현재 제가 구상한 방안은 다음과 같습니다.
      1) `ConcertScheduleRepository.findAllAvailable(LocalDateTime now)` :  공연 일정의 '예약 시작 날짜' / '예약 종료 날짜' 관점에서 현재 기준 예매가 가능한 공연 일정 조회.
      2) `SeatRepository.findAllByConcertScheduleId(String concertScheduleId)` : 공연 일정 도메인 모델의 식별자를 인자로 받아 해당 공연 일정 ID에 부합하는 좌석(예매 불가 / 가능) 목록 조회
      3) 이 둘의 결과를 Service 단에서 다음과 같이 처리하여 원하는 결과를 filter 해낸다.
         ```java
              public List<ConcertSchedule> getAvailableConcertSchedules() {
                      LocalDateTime now = LocalDateTime.now();
        
                      // 예약 날짜가 현재보다 이후인 ConcertSchedule 조회
                      List<ConcertSchedule> schedules = concertScheduleRepository.findAllAvailableConcertSchedule(now);
        
                      // 예약 가능한 좌석이 있는 ConcertSchedule 필터링
                      return schedules.stream()
                                                    .filter(cs -> seatRepository.findAllAvailableByConcertScheduleId(cs.getId()).size() > 0)
                                                    .collect(Collectors.toList());
         ```
         이 방법은 다음과 같은 세 가지를 고려했습니다.
          - 쿼리 의존적이지 않게 구현
          - 도메인 모델 분리를 한 이상 책임도 명확하게 나눌것
          
          이 방법이 유효한지, 문제가 있다면 어떤 부분에서 문제가 있는지 알고싶습니다.
          또 코치님이라면 어떻게 하실지도 궁금합니다..!
          
 3. 현재 설계 전반이 코치님이 요구하신 부분을 잘 수용한 설계인지 궁금합니다.
      또한 도메인 모델 / JPA Entity 모델 분리와 이에 기반한 비즈니스 로직 구현도 너무 비효율적이진 않은지 여쭤보고 싶습니다.
          
## 아쉬웠던 점
- 도메인 모델의 ID 필드가 Nullable 해도 괜찮다는 말씀을 아주.. 늦게,, 제출 직전에야 이해했습니다...
   빨리 이해했다면 단위 테스트가 이렇게까지 복잡해지진 않았을 것 같습니다...ㅠㅠ

