### PR TITLE
STEP 18 : Kafka 기반 Transaction Outbox Pattern 적용

### DIFF
--- a/src/main/java/com/hhp7/concertreservation/Hhp7ConcertReservationApplication.java
+++ b/src/main/java/com/hhp7/concertreservation/Hhp7ConcertReservationApplication.java
@@ -2,8 +2,10 @@ package com.hhp7.concertreservation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Hhp7ConcertReservationApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/hhp7/concertreservation/application/event/listener/ReservationConfirmationEventListener.java
+++ b/src/main/java/com/hhp7/concertreservation/application/event/listener/ReservationConfirmationEventListener.java
@@ -1,5 +1,6 @@
 package com.hhp7.concertreservation.application.event.listener;
 
+import com.hhp7.concertreservation.application.event.publisher.OutboxDomainEventPublisher;
 import com.hhp7.concertreservation.domain.point.service.PointService;
 import com.hhp7.concertreservation.domain.reservation.event.ReservationConfirmationEvent;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ReservationConfirmationEventListener {
 
     private final PointService pointService;
+    private final OutboxDomainEventPublisher outboxPublisher;
 
     /**
      * 예약 확정 이벤트 수신 시 -> 사용자 포인트 차감
@@ -32,6 +34,19 @@ public class ReservationConfirmationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     public void handleReservationConfirmationEventRollback(ReservationConfirmationEvent reservationConfirmationEvent) {
         pointService.increaseUserPointBalance(reservationConfirmationEvent.userId(), reservationConfirmationEvent.price());
+    }
+
+    /**
+     * 예약 확정 이벤트 발생 시 -> 아웃박스 발행
+     * <br></br>
+     * 이벤트 발행 시점은 트랜잭션 커밋 전이며, 이벤트 발행 실패 시 롤백됩니다.
+     * @param event
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleReservationConfirmEvent(ReservationConfirmationEvent event) {
+        // "ReservationService" is used as a 'from' identifier
+        outboxPublisher.publish(event, "ReservationService");
+        log.info("해당 예약 확정 정보 아웃박스 저장 호출 : {}", event.reservationId());
     }
 
 

--- a/src/main/java/com/hhp7/concertreservation/application/event/publisher/OutboxDomainEventPublisher.java
+++ b/src/main/java/com/hhp7/concertreservation/application/event/publisher/OutboxDomainEventPublisher.java
@@ -1,0 +1,66 @@
+package com.hhp7.concertreservation.application.event.publisher;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhp7.concertreservation.infrastructure.outbox.OutboxJpaEntity;
+import com.hhp7.concertreservation.infrastructure.outbox.OutboxRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 도메인 이벤트를 아웃박스에 저장하는 서비스.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxDomainEventPublisher {
+
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;  // Inject Jackson's ObjectMapper
+
+    @Transactional
+    public void publish(Object domainEvent, String from) {
+        try {
+            // Serialize the domain event to JSON
+            String payload = objectMapper.writeValueAsString(domainEvent);
+
+            // Create an outbox entity with the payload and metadata
+            OutboxJpaEntity outboxEntity = OutboxJpaEntity.builder()
+                    .id(UUID.randomUUID().toString())
+                    .payload(payload)
+                    .topicIdentifier(determineTopicName(domainEvent.getClass()))
+                    .eventType(domainEvent.getClass().getName())
+                    .retryCount(0)
+                    .build()
+                    .initiateStatus();
+
+            // Save the outbox entity in the same transaction as your domain change
+
+            outboxRepository.save(outboxEntity);
+            log.info("아웃박스로 저장 성공 : {} / 아웃박스 토픽 이름 : {}", outboxEntity.getId(), outboxEntity.getTopicIdentifier());
+
+        } catch (JsonProcessingException e) {
+            log.info("아웃박스로 저장 실패 : {}", e.getMessage());
+            throw new RuntimeException("Failed to serialize event", e);
+        }
+    }
+
+    /**
+     * 도메인 이벤트 클래스 이름을 topic 이름으로 변환합니다.
+     * @param eventClassName
+     * @return
+     */
+    private String determineTopicName(Class<?> eventClass) {
+        String simpleName = eventClass.getSimpleName(); // e.g. "ReservationConfirmationEvent"
+        // Remove "Event" suffix
+        if(simpleName.endsWith("Event")){
+            simpleName = simpleName.substring(0, simpleName.length() - "Event".length());
+        }
+        // Convert camelCase to hyphen-delimited lower-case
+        return simpleName.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase();
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/application/scheduler/OutboxScheduler.java
+++ b/src/main/java/com/hhp7/concertreservation/application/scheduler/OutboxScheduler.java
@@ -1,0 +1,56 @@
+package com.hhp7.concertreservation.application.scheduler;
+
+import com.hhp7.concertreservation.infrastructure.outbox.OutboxJpaEntity;
+import com.hhp7.concertreservation.infrastructure.outbox.OutboxService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final OutboxService outboxService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    //
+    @Scheduled(fixedDelay = 10)
+    public void sendOutboxMessages() {
+        log.info("아웃박스 메세지 전송 시작");
+        List<OutboxJpaEntity> pending = outboxService.getAllPendingOutbox();
+        for (OutboxJpaEntity entity : pending) {
+            try {
+                // Topic 이름
+                String topic = entity.getTopicIdentifier();
+                kafkaTemplate.send(topic, entity.getPayload()).get();
+                entity.updateToSent();
+                outboxService.put(entity);
+                log.info("아웃박스 저장내역 카프카로 발행 성공 : {}", entity.getId());
+            } catch (Exception e) {
+                log.error("Error sending outbox event id {}: {}", entity.getId(), e.getMessage());
+                entity.increaseRetryCount();
+                if (entity.isExceedMaxRetryCount()) {
+                    entity.updateToError();
+                }
+                outboxService.put(entity);
+            }
+        }
+    }
+
+    // 아웃박스 전송 완료 항목 제거
+    @Scheduled(fixedDelay = 10000) // 10초 간격 순회하며 작업.
+    public void removeSentOutbox() {
+        outboxService.deleteAllSent();
+    }
+
+    @Scheduled(fixedDelay = 3000) // 3초 간격 순회하며 작업.
+    public void retryErrorOutbox() {
+        outboxService.retryAllError();
+    }
+
+
+}

--- a/src/main/java/com/hhp7/concertreservation/application/scheduler/QueueScheduler.java
+++ b/src/main/java/com/hhp7/concertreservation/application/scheduler/QueueScheduler.java
@@ -21,7 +21,7 @@ public class QueueScheduler {
 
     // Queue 내에 저장된 Token을 만료시키고 만료시킨 토큰 수만큼 활성화 시켜준다.
     @Scheduled(fixedDelay = 10000) // 10초 간격 순회하며 작업.
-    public void expireAndActivateToken(String concertScheduleId) {
+    public void expireAndActivateToken() {
 
         // 현재 예약 진행 중인 공연 전체 조회 : 캐싱 적용하여 해당 데이터 캐시에 존재할 경우, Redis 캐시로부터 가져옵니다!
         List<ConcertSchedule> onGoingConcertSchedules = concertService.getOngoingConcertSchedules(LocalDateTime.now());
@@ -33,9 +33,9 @@ public class QueueScheduler {
             // 만료 대상 토큰이 존재할 경우 -> 만료 시키기.
             if(!activeTokensToBeExpired.isEmpty()){
                 // 만료 대상 토큰 만료 처리.
-                queueService.expireToken(concertScheduleId, activeTokensToBeExpired);
+                queueService.expireToken(concertSchedule.getId(), activeTokensToBeExpired);
                 // 정책 상 설정된 활성화 갯수만큼 토큰 활성화.
-                queueService.activateTokens(concertScheduleId, ACTIVATION_BATCH_SIZE);
+                queueService.activateTokens(concertSchedule.getId(), ACTIVATION_BATCH_SIZE);
             }
         }
     }

--- a/src/main/java/com/hhp7/concertreservation/domain/dataplatform/application/listener/ReservationConfirmStorageListener.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/dataplatform/application/listener/ReservationConfirmStorageListener.java
@@ -1,0 +1,26 @@
+package com.hhp7.concertreservation.domain.dataplatform.application.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhp7.concertreservation.domain.reservation.event.ReservationConfirmationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationConfirmStorageListener {
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "reservation-confirm", groupId = "dataplatform-group")
+    public void consumeReservationConfirm(String message) {
+        try {
+            ReservationConfirmationEvent event = objectMapper.readValue(message, ReservationConfirmationEvent.class);
+            log.info("성공적으로 예약 확정 정보 수령! : [{}]", event.reservationId());
+        } catch (Exception e) {
+            log.error("Error processing message in dataplatform consumer: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/domain/reservation/event/consumer/OutboxSelfConsumer.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/reservation/event/consumer/OutboxSelfConsumer.java
@@ -1,0 +1,27 @@
+package com.hhp7.concertreservation.domain.reservation.event.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhp7.concertreservation.domain.reservation.event.ReservationConfirmationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxSelfConsumer {
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "reservation-confirmation", groupId = "publisher-self-group")
+    public void consumeSelf(String message) {
+        try {
+            ReservationConfirmationEvent event = objectMapper.readValue(message, ReservationConfirmationEvent.class);
+            log.info("예약 확정 이벤트를 담은 메세지 발행 확인: [{}]", event.reservationId());
+
+        } catch (Exception e) {
+            log.error("셀프 컨슈머에서 문제 발생: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/hhp7/concertreservation/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/reservation/service/ReservationService.java
@@ -110,7 +110,7 @@ public class ReservationService {
         Reservation confirmedReservation = reservationRepository.save(reservation); // 확정된 예약 저장.
         log.info("결제 완료 후 예약 확정되어 저장된 Reservation 상태 : {}", confirmedReservation.getStatus());
 
-        // applicationEventPublisher.publishEvent(ReservationConfirmationEvent.fromDomain(confirmedReservation)); // 이벤트 발행
+        applicationEventPublisher.publishEvent(ReservationConfirmationEvent.fromDomain(confirmedReservation)); // 이벤트 발행
 
         return confirmedReservation;
     }

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxJpaEntity.java
@@ -1,0 +1,59 @@
+package com.hhp7.concertreservation.infrastructure.outbox;
+
+import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.BaseJpaEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "outbox")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboxJpaEntity extends BaseJpaEntity {
+
+    @Id
+    private String id;
+
+    private String payload;
+
+    private OutboxStatus status;
+
+    private String eventType; // 이벤트 타입
+
+    private String topicIdentifier; // 토픽 식별자
+
+    private int retryCount;
+
+    public void increaseRetryCount() {
+        retryCount++;
+    }
+
+    public boolean isExceedMaxRetryCount() {
+        return retryCount > 5;
+    }
+
+    public OutboxJpaEntity updateToSent() {
+        this.status = OutboxStatus.SENT;
+        return this;
+    }
+
+    public OutboxJpaEntity updateToError() {
+        this.status = OutboxStatus.ERROR;
+        this.retryCount = 0;
+        return this;
+    }
+
+    public OutboxJpaEntity initiateStatus() {
+        this.status = OutboxStatus.PENDING;
+        return this;
+    }
+
+
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxRepository.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxRepository.java
@@ -1,0 +1,23 @@
+package com.hhp7.concertreservation.infrastructure.outbox;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OutboxRepository extends JpaRepository<OutboxJpaEntity, String> {
+
+    @Query("select o from OutboxJpaEntity o where o.status = com.hhp7.concertreservation.infrastructure.outbox.OutboxStatus.PENDING")
+    List<OutboxJpaEntity> findPendingOutbox();
+
+    @Query("select o from OutboxJpaEntity o where o.status = com.hhp7.concertreservation.infrastructure.outbox.OutboxStatus.ERROR")
+    List<OutboxJpaEntity> findErrorOutbox();
+
+    @Query("select o from OutboxJpaEntity o where o.status = com.hhp7.concertreservation.infrastructure.outbox.OutboxStatus.ERROR and o.retryCount >= 5")
+    List<OutboxJpaEntity> findExceedMaxRetryCountOutbox();
+
+    @Query("select o from OutboxJpaEntity o where o.status = com.hhp7.concertreservation.infrastructure.outbox.OutboxStatus.SENT")
+    List<OutboxJpaEntity> findAllSent();
+
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxService.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxService.java
@@ -1,0 +1,78 @@
+package com.hhp7.concertreservation.infrastructure.outbox;
+
+import com.hhp7.concertreservation.exceptions.UnavailableRequestException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final OutboxRepository outboxRepository;
+
+    @Transactional
+    public OutboxJpaEntity put(OutboxJpaEntity outboxJpaEntity) {
+        return outboxRepository.save(outboxJpaEntity);
+    }
+
+    public OutboxJpaEntity get(String outboxId) {
+        return outboxRepository.findById(outboxId)
+                .orElseThrow(() -> new UnavailableRequestException("해당 아웃박스가 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void remove(String outboxId) {
+        outboxRepository.deleteById(outboxId);
+    }
+
+    @Transactional
+    public OutboxJpaEntity markAsSent(String outboxId) {
+        OutboxJpaEntity outboxJpaEntity = get(outboxId);
+        outboxJpaEntity.updateToSent();
+        return outboxRepository.save(outboxJpaEntity);
+    }
+
+    @Transactional
+    public OutboxJpaEntity markAsError(String outboxId) {
+        OutboxJpaEntity outboxJpaEntity = get(outboxId);
+        outboxJpaEntity.updateToError();
+        outboxJpaEntity.increaseRetryCount(); // 재시도횟수 증가.
+        return outboxRepository.save(outboxJpaEntity);
+    }
+
+    @Transactional
+    public void retry(String outboxId) {
+        OutboxJpaEntity outboxJpaEntity = get(outboxId);
+        outboxJpaEntity.increaseRetryCount();
+        outboxRepository.save(outboxJpaEntity);
+    }
+
+    @Transactional
+    public void retryAllError() {
+        outboxRepository.findErrorOutbox().forEach(outboxJpaEntity -> {
+            outboxJpaEntity.increaseRetryCount();
+            outboxRepository.save(outboxJpaEntity);
+        });
+    }
+
+    @Transactional
+    public void deleteAllSent(){
+        outboxRepository.deleteAll(outboxRepository.findAllSent());
+    }
+
+    public List<OutboxJpaEntity> getAllPendingOutbox() {
+        return outboxRepository.findPendingOutbox();
+    }
+
+    public List<OutboxJpaEntity> getAllErrorOutbox() {
+        return outboxRepository.findErrorOutbox();
+    }
+
+    public List<OutboxJpaEntity> getAllExceedMaxRetryCountOutbox() {
+        return outboxRepository.findExceedMaxRetryCountOutbox();
+    }
+
+
+}

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxStatus.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.hhp7.concertreservation.infrastructure.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    SENT,
+    ERROR // 5회 이상 전송 시도 후 실패 시 상태 변경
+}

--- a/src/test/java/com/hhp7/concertreservation/application/NonConcurrentConcertReservationIntegrationTest.java
+++ b/src/test/java/com/hhp7/concertreservation/application/NonConcurrentConcertReservationIntegrationTest.java
@@ -216,25 +216,13 @@ public class NonConcurrentConcertReservationIntegrationTest {
 
             concertReservationApplication.paymentRequestForReservation(user.getId(), seat.getPrice(), createdTemporaryReservation.getId()); // 결제 요청
 
-            // Poll for up to 5 seconds, checking every 200ms if the reservation is now PAID
-            long startTime = System.currentTimeMillis();
-            long maxWaitMillis = 5000;
-            boolean isPaid = false;
-
-            while ((System.currentTimeMillis() - startTime) < maxWaitMillis) {
-                Reservation current = concertReservationApplication.getReservation(createdTemporaryReservation.getId());
-                if (current.getStatus() == ReservationStatus.PAID) {
-                    isPaid = true;
-                    break;
-                }
-                Thread.sleep(200); // wait 200ms before next check
-            }
-
             UserPointBalance updatedUserPointBalance = concertReservationApplication.getUserPointBalance(user.getId()); // 차감된 사용자 잔액
             Seat reservedSeat = concertReservationApplication.getSeat(seat.getId()); // 예약된 좌석
             Reservation confirmedReservation = concertReservationApplication.getReservation(createdTemporaryReservation.getId()); // 확정된 예약
             log.warn("결제 완료 후 예약 확정되어 저장된 Reservation 상태 : {}", confirmedReservation.getStatus());
             log.warn("결제 완료 후 예약 확정되어 저장된 Reservation ID : {}", confirmedReservation.getId());
+
+            Thread.sleep(1000);
 
             // then
             Assertions.assertEquals(updatedUserPointBalance.balance().getAmount(), 1000);


### PR DESCRIPTION
## 과제 이전 작업 내용
> 1. `ApplicationEventPublisher` 및 CustomEvent 활용하여 파사드 해체
 - 여전히 Facade 클래스는 남아있으나, Choreography 기반의 Saga 패턴 적용에 따른 단일 진입점이 될 메서드 호출 책임만 수행합니다.
   트랜잭션은 모두 로컬 트랜잭션으로 리팩터하였습니다.
> 2.  Choreography 기반 Saga 패턴 방식의 보상트랜잭션 적용

## 이번 과제 작업 내용
> 1. 예약 결제(예약 확정) 처리된 예약 정보를 데이터플랫폼으로 Kafka를 MQ로 활용한 전송. 

## 피드백 요청 사항
> **코리오그래피 방식의 사가 패턴 적용 시 이벤트 별 토픽 설계**
- 현재 저는 이벤트 주도 설계로 리팩터를 하는 과정에서, 코리오그래피 방식의 사가 패턴으로 보상트랜잭션을 구현하였습니다.
   이때 Kafka를 MQ로 활용하는 구현을 도입할 경우, 롤백에 대한 이벤트도 반드시 전달되어야 하고 이러한 롤백이 다른 성공 메세지와 같은 파티션을 쓰게될 경우 다음의 이유로 좋지 않을 것이라고 판단했습니다.
    1) 실패로 인한 롤백은 서비스 운용사항에서 빈도나 성격 측면에서 모두 특수한 상황입니다. 
    이를 알리는 메세지가 '정상적인 서비스 운영을 위한 메세지'와 함께 섞여 전달되는 것은 특수한 상황 때문에 정상적인 상황에 대한 대처 능력을 떨어뜨릴 수 있다고 생각했습니다. 
    
    이에 대해코치님의 고견이 궁금합니다.
   
> **선착순 쿠폰 기능에서의 카프카 Partition 설계 고민**
  - 우선 선착순 쿠폰의 비즈니스 유즈케이스에서도 트래픽이 짧은 시간동안 많이 몰려 대기열이 필요하다는 전제를 해보았습니다.
     이때 대기열은 지금 콘서트와 마찬가지로 Redis 로 구현한다고 가정해보았습니다.
  - 선착순 쿠폰 자체가 배타적 선점 대상이고, 이를 카프카를 활용하여 구현한다면 "카프카의 순차 지원 및 At-most-once" 성격을 활용한다는 방향을 고민해보았습니다.

> <카프카를 활용한 선착순 쿠폰 발급 로직 설계>
> 1. Redis 기반 대기열을 통해 서버 인스턴스 자체에 진입하는 트래픽이 통제 가능하도록 제어한다(약 40명 동시 이용)
> 2. 발급 이벤트 전 Partition 이 1개인 `coupon` 이라는 토픽에 DB 내 존재하는 쿠폰의 PK 를 담은 메세지를 미리 적재한다.
> 3. 대기열을 거쳐 서비스에 진입한 인원이 쿠폰 발급 endpoint 에 요청을 할 경우, 해당 도메인 서비스는 이 Partition 을 consume 한다.

이 방식으로라면 선착순 쿠폰 발급 시 쿠폰에 대한 동시성 제어를 효율적으로 구현할 수 있을 것 같다고 생각했습니다.
이러한 설계가 충분히 설득력이 있는지 여쭤보고싶습니다.
    
> **현행 구조 적절성 평가 요청**

현재, 제가 설계한 과제 (결제 확정 시 데이터 플랫폼으로 해당 확정 예약 정보 전송)은 다음과 같은 시퀀스로 진행됩니다.

1) 예약 확정 시 `ReservationConfirmationEvent` 발행 : 예약 확정 로직에는 `@Transactional`이 있습니다.
2) 해당 이벤트를 Listen 하는 `ReservationConfirmationEventListener` 
```java
@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
public void handleReservationConfirmationWithOutboxPost(){
      ...
      outboxService.put(outbox) // 해당 서비스 로직은 @Transactional 이 붙어있습니다.
}
```
3) `outboxService.put(outbox)` 를 통해 발행된 메세지 저장
 - 이때 해당 서비스 로직에도 `@Transactional` 이 붙어있으므로, 둘은 결국 TransactionSynchronizationManager 에 의해 "하나의 트랜잭션" 으로 관리되어 함께 커밋된다.

4) 스케쥴러가 이를 Kafka 로 전송한다.

위와 같이 설계한 이유는, 도메인 서비스 로직 내부에서 바로 `outboxService.put(outbox)` 를 호출하는 것이 도메인을 오염시킨다고 생각했기 때문입니다.

혹시 이러한 설계가 너무 지나치게 복잡하지 않은지, 코치님이 보시기엔 어떻고 만약 코치님이라면 어떻게 구현하실지 여쭤보고싶습니다.!

## 아쉬운 점
다음 주 부하 테스트를 진행하기 위해선 이벤트 기반으로 리팩터를 잘해서 문제 없이 돌아가야할 것 같아.. 여기에 시간을 쏟느라 보고서는 정리만 해두고 제대로 제출을 하지 못했습니다. 부끄럽습니다,,ㅠㅠ

