### PR TITLE
<feat> : Transaction Outbox Entity 의 payload : json 타입으로 변경 외 fixes

### DIFF
--- a/src/main/java/com/hhp7/concertreservation/application/event/listener/ReservationConfirmationEventListener.java
+++ b/src/main/java/com/hhp7/concertreservation/application/event/listener/ReservationConfirmationEventListener.java
@@ -17,15 +17,6 @@ public class ReservationConfirmationEventListener {
     private final PointService pointService;
     private final OutboxDomainEventPublisher outboxPublisher;
 
-    /**
-     * 예약 확정 이벤트 수신 시 -> 사용자 포인트 차감
-     * @param reservationConfirmationEvent
-     */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleReservationConfirmationEvent(ReservationConfirmationEvent reservationConfirmationEvent) {
-        // 로깅
-        log.info("예약 확정 이벤트 수신: userId: {}, point: {}", reservationConfirmationEvent.userId(), reservationConfirmationEvent.price());
-    }
 
     /**
      * 예약 확정 이벤트 롤백 시 -> 사용자 포인트 증가
@@ -33,6 +24,7 @@ public class ReservationConfirmationEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     public void handleReservationConfirmationEventRollback(ReservationConfirmationEvent reservationConfirmationEvent) {
+        log.info("예약 확정 이벤트 롤백: userId: {}, point: {}", reservationConfirmationEvent.userId(), reservationConfirmationEvent.price());
         pointService.increaseUserPointBalance(reservationConfirmationEvent.userId(), reservationConfirmationEvent.price());
     }
 
@@ -45,7 +37,7 @@ public class ReservationConfirmationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleReservationConfirmEvent(ReservationConfirmationEvent event) {
         // "ReservationService" is used as a 'from' identifier
-        outboxPublisher.publish(event, "ReservationService");
+        outboxPublisher.publish(event);
         log.info("해당 예약 확정 정보 아웃박스 저장 호출 : {}", event.reservationId());
     }
 

--- a/src/main/java/com/hhp7/concertreservation/application/event/publisher/OutboxDomainEventPublisher.java
+++ b/src/main/java/com/hhp7/concertreservation/application/event/publisher/OutboxDomainEventPublisher.java
@@ -3,6 +3,7 @@ package com.hhp7.concertreservation.application.event.publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hhp7.concertreservation.infrastructure.outbox.OutboxJpaEntity;
 import com.hhp7.concertreservation.infrastructure.outbox.OutboxRepository;
 import java.util.UUID;
@@ -23,29 +24,30 @@ public class OutboxDomainEventPublisher {
     private final ObjectMapper objectMapper;  // Inject Jackson's ObjectMapper
 
     @Transactional
-    public void publish(Object domainEvent, String from) {
+    public void publish(Object domainEvent) {
         try {
-            // Serialize the domain event to JSON
-            String payload = objectMapper.writeValueAsString(domainEvent);
+            // 도메인 이벤트를 직렬화
+            String payload = objectMapper
+                    .registerModule(new JavaTimeModule()) // LocalDateTime 직렬화를 위한 모듈 등록
+                    .writeValueAsString(domainEvent);
 
-            // Create an outbox entity with the payload and metadata
+            // 아웃박스 엔티티 생성
             OutboxJpaEntity outboxEntity = OutboxJpaEntity.builder()
                     .id(UUID.randomUUID().toString())
                     .payload(payload)
                     .topicIdentifier(determineTopicName(domainEvent.getClass()))
-                    .eventType(domainEvent.getClass().getName())
                     .retryCount(0)
                     .build()
                     .initiateStatus();
 
-            // Save the outbox entity in the same transaction as your domain change
-
+            // 아웃박스 저장
             outboxRepository.save(outboxEntity);
+
             log.info("아웃박스로 저장 성공 : {} / 아웃박스 토픽 이름 : {}", outboxEntity.getId(), outboxEntity.getTopicIdentifier());
 
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
             log.info("아웃박스로 저장 실패 : {}", e.getMessage());
-            throw new RuntimeException("Failed to serialize event", e);
+            throw new RuntimeException("예외가 발생하여 아웃박스 저장에 실패하였습니다.", e);
         }
     }
 

--- a/src/main/java/com/hhp7/concertreservation/application/facade/ConcertReservationApplication.java
+++ b/src/main/java/com/hhp7/concertreservation/application/facade/ConcertReservationApplication.java
@@ -166,8 +166,8 @@ public class ConcertReservationApplication {
      * @param seatId
      * @return
      */
-    public String paymentRequestForReservation(String userId, Integer price, String reservatinId){
-        pointService.processPaymentForReservation(userId, price, reservatinId);
+    public String paymentRequestForReservation(String userId, Integer price, String reservationId){
+        pointService.processPaymentForReservation(userId, price, reservationId);
         return "결제 완료";
     }
 

--- a/src/main/java/com/hhp7/concertreservation/application/scheduler/OutboxScheduler.java
+++ b/src/main/java/com/hhp7/concertreservation/application/scheduler/OutboxScheduler.java
@@ -22,6 +22,7 @@ public class OutboxScheduler {
     public void sendOutboxMessages() {
         log.info("아웃박스 메세지 전송 시작");
         List<OutboxJpaEntity> pending = outboxService.getAllPendingOutbox();
+        log.info("아웃박스 메세지 전송 대상 수 : {}", pending.size());
         for (OutboxJpaEntity entity : pending) {
             try {
                 // Topic 이름

--- a/src/main/java/com/hhp7/concertreservation/application/scheduler/ReservationScheduler.java
+++ b/src/main/java/com/hhp7/concertreservation/application/scheduler/ReservationScheduler.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(isolation = Isolation.REPEATABLE_READ)
 public class ReservationScheduler {
     private final ReservationService reservationService;
-    private final ConcertService concertService;
 
     // 가예약 만료 처리
     @Scheduled(fixedDelay = 10000) // 약 10초 간격 순회하며 작업.

--- a/src/main/java/com/hhp7/concertreservation/domain/reservation/event/consumer/OutboxSelfConsumer.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/reservation/event/consumer/OutboxSelfConsumer.java
@@ -14,7 +14,7 @@ public class OutboxSelfConsumer {
 
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "reservation-confirmation", groupId = "publisher-self-group")
+    @KafkaListener(topics = "reservation-confirmation", groupId = "concert")
     public void consumeSelf(String message) {
         try {
             ReservationConfirmationEvent event = objectMapper.readValue(message, ReservationConfirmationEvent.class);

--- a/src/main/java/com/hhp7/concertreservation/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/hhp7/concertreservation/domain/reservation/service/ReservationService.java
@@ -101,7 +101,7 @@ public class ReservationService {
      * 해당 예약 상태를 {@code ReservationStatus.PAID} 로 변경합니다.
      * @param concertScheduleId, userId, seatId
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Reservation confirmReservation(String reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new UnavailableRequestException("해당 가예약이 존재하지 않습니다.")); // 해당 가예약 조회.

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/kafka/KafkaProducerConfig.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.config.kafka;
+package com.hhp7.concertreservation.infrastructure.kafka;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 
@@ -19,7 +20,7 @@ public class KafkaProducerConfig {
     private String bootstrapServer;
 
     @Bean
-    public ProducerFactory<String, Object> producerFactory() {
+    public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -29,7 +30,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate() {
+    public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxJpaEntity.java
+++ b/src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxJpaEntity.java
@@ -1,6 +1,7 @@
 package com.hhp7.concertreservation.infrastructure.outbox;
 
 import com.hhp7.concertreservation.infrastructure.persistence.jpa.entities.BaseJpaEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -9,6 +10,10 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+import org.hibernate.boot.model.TypeDefinition;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "outbox")
@@ -21,11 +26,11 @@ public class OutboxJpaEntity extends BaseJpaEntity {
     @Id
     private String id;
 
+    @Column(columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
     private String payload;
 
     private OutboxStatus status;
-
-    private String eventType; // 이벤트 타입
 
     private String topicIdentifier; // 토픽 식별자
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
 logging:
   level:
     org:
-      springframework: info
+      springframework: DEBUG
     com:
       hhp7:
         concertreservation:

--- a/src/test/java/com/hhp7/concertreservation/application/ConcurrentConcertReservationIntegrationTest.java
+++ b/src/test/java/com/hhp7/concertreservation/application/ConcurrentConcertReservationIntegrationTest.java
@@ -3,15 +3,12 @@ package com.hhp7.concertreservation.application;
 import com.hhp7.concertreservation.application.facade.ConcertReservationApplication;
 import com.hhp7.concertreservation.application.facade.UserApplication;
 import com.hhp7.concertreservation.domain.concert.model.ConcertSchedule;
-import com.hhp7.concertreservation.domain.concert.model.ConcertScheduleAvailability;
 import com.hhp7.concertreservation.domain.concert.model.Seat;
 import com.hhp7.concertreservation.domain.concert.model.SeatStatus;
 import com.hhp7.concertreservation.domain.concert.repository.ConcertScheduleRepository;
 import com.hhp7.concertreservation.domain.concert.repository.SeatRepository;
 import com.hhp7.concertreservation.domain.concert.service.ConcertService;
 import com.hhp7.concertreservation.domain.point.model.UserPointBalance;
-import com.hhp7.concertreservation.domain.reservation.model.Reservation;
-import com.hhp7.concertreservation.domain.reservation.model.ReservationStatus;
 import com.hhp7.concertreservation.domain.reservation.repository.ReservationRepository;
 import com.hhp7.concertreservation.domain.user.model.User;
 import com.hhp7.concertreservation.exceptions.BusinessRuleViolationException;
@@ -63,6 +60,7 @@ public class ConcurrentConcertReservationIntegrationTest {
 
     @Nested
     class ConcertReservationTest {
+
         @Test
         @DisplayName("성공 : 서로 다른 50개 좌석에 대한 동시 좌석 선점(가예약) 시도 -> 모두 성공, 예약 가능 잔여 좌석 0.")
         void concurrentReservationsForDifferentSeats() throws InterruptedException, ExecutionException {

--- a/src/test/java/com/hhp7/concertreservation/application/NonConcurrentConcertReservationIntegrationTest.java
+++ b/src/test/java/com/hhp7/concertreservation/application/NonConcurrentConcertReservationIntegrationTest.java
@@ -1,8 +1,5 @@
 package com.hhp7.concertreservation.application;
 
-import static org.assertj.core.api.Fail.fail;
-import static org.mockito.Mockito.verify;
-
 import com.hhp7.concertreservation.application.event.listener.PaymentEventListener;
 import com.hhp7.concertreservation.application.facade.ConcertReservationApplication;
 import com.hhp7.concertreservation.application.facade.UserApplication;
@@ -35,8 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Commit;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 public class NonConcurrentConcertReservationIntegrationTest {
@@ -111,6 +106,7 @@ public class NonConcurrentConcertReservationIntegrationTest {
 
     @Nested
     class UserPointIntegrationTest {
+
         @Test
         @DisplayName("성공 : 회원 가입 시 해당 회원의 포인트 잔액 0인 UserPointBalance가 생성되어 저장된다. 이때 INIT 타입의 PointHistory도 생성되어 저장된다.")
         void shouldCreateAndSaveUserPointBalanceWith0AndInitPointHistory_WhenUserSignedUp() {
@@ -170,19 +166,19 @@ public class NonConcurrentConcertReservationIntegrationTest {
 
     @Nested
     class ConcertReservationIntegrationTest {
+
         @Test
         @DisplayName("성공 : 예약 가능한 공연 일정을 조회한다.")
         void shouldSuccessfullyGetAvailableConcertSchedule() {
             // given
-            ConcertSchedule expected = concertReservationApplication.registerConcertSchedule("1", concertDateTime, reservationStartAt, reservationEndAt, 1000);
+            ConcertSchedule expected = concertReservationApplication.registerConcertSchedule("1", concertDateTime.plusDays(1), reservationStartAt.plusDays(1), reservationEndAt.plusDays(1), 1000);
 
             // when
             List<ConcertSchedule> actual = concertReservationApplication.getAvailableConcertSchedules();
 
             // then
             Assertions.assertNotNull(actual);
-            Assertions.assertEquals(1, actual.size());
-            Assertions.assertEquals(expected.getId(), actual.get(0).getId());
+            Assertions.assertEquals(2, actual.size());
         }
 
         @Test
@@ -215,6 +211,7 @@ public class NonConcurrentConcertReservationIntegrationTest {
                     = concertReservationApplication.createTemporaryReservation(user.getId(), concertSchedule.getId(), assignedSeat.getId(), assignedSeat.getPrice()); // 가예약 생성
 
             concertReservationApplication.paymentRequestForReservation(user.getId(), seat.getPrice(), createdTemporaryReservation.getId()); // 결제 요청
+
 
             UserPointBalance updatedUserPointBalance = concertReservationApplication.getUserPointBalance(user.getId()); // 차감된 사용자 잔액
             Seat reservedSeat = concertReservationApplication.getSeat(seat.getId()); // 예약된 좌석


### PR DESCRIPTION
### PR 핵심
 1. Transaction outbox JPA entity 의 payload 타입 : String -> json type 수정
> 변경사항 적용 부분 : [링크](src/main/java/com/hhp7/concertreservation/infrastructure/outbox/OutboxJpaEntity.java)
> 변경 원인 : payload 필드에 담길 String 데이터가 너무 길어 MySQL 삽입 시 예외 발생

> 해결을 위한 과정
 - Payload 에 Event 객체를 그대로 직렬화하여 넣는 방안이 적절한지 재검토
   - 하지만 예약 확정 과정에서 예외가 발생하여 Choreography 패턴에 의한 보상 트랜잭션을 통한 롤백 전파 시,
      결제 롤백을 위해 해당 예약과 관련한 필요한 정보 - 사용자 식별자, 공연 일정 및 좌석 식별자 - 등을 포함할 필요가 있었다.
    - 동시에 Event 객체 디자인 당시 필요한 정보만 담을 수 있도록 불필요한 정보를 제거했기 때문에 Event 객체 직렬화는 여전히 필요했다.
 - Payload 의 현행 타입(`String`) 적절성에 대한 고민
   - 이보다 복잡한 프로젝트에서는 Event 객체가 담고있는 정보가 이 보다 많을 수 있음을 고려했을 때,
      실제로는 payload 에 `VARCHAR(255)` 로 표현되는 String 필드 타입이 아닌 다른 필드 타입을 사용할 가능성이 높다고 판단하였다.
    - 이에 따라 웹 검색을 통해 다른 개발자들이 payload 필드의 타입으로 어떤 데이터 타입을 사용하는지 살펴보았고, `ObjectMapper` 로 직렬화된 JSON 형태의 데이터를 JSON 타입 그대로 넣을 수 있도록 MySQL 5.7 부터 지원하고있음을 파악했다.
       Oracle DB 또한 JSON 이 Attribute type 으로 설정될 수 있도록 지원하고 있음을 확인했다.
     - 따라서, `payload`  필드를 JSON 타입 필드로 정의하기로 결정하였다. 
  - JPA 의 구현체로 Hibernate 를 사용하고 있었기 때문에,
     [Hibernate 공식문서](https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html#basic-mapping-json)를 참고하여 적용하였다.
> 해결
 - JSON 타입으로 매핑되도록 코드를 수정한 후 해당 문제는 완전히 해결되었다.
 
 > Lesson Learnt
 - MySQL 5.7 부터는 `JSON` 타입 필드를 지원한다.
   - `JSON` 타입은 내부적으로 `LONGTEXT` 타입 필드와 동일하게 취급된다. [출처](https://dev.mysql.com/doc/refman/8.4/en/json.html)
   - 또한, 해당 타입 필드의 최대 길이는 MySQL 시스템 변수인 `max_allowed_packet` 값에 따라 결정된다. [출처](https://dev.mysql.com/doc/refman/8.4/en/json.html)
   
      